### PR TITLE
HC-21 Don't fail script if docker reset fails

### DIFF
--- a/templates/docker-ephemeral-lvm.sh
+++ b/templates/docker-ephemeral-lvm.sh
@@ -259,5 +259,5 @@ EOF
 
 fi
 
-$reset_docker
+$reset_docker || "No need to reset. Moving on"
 $start_docker


### PR DESCRIPTION
Simply prints a message if the docker reset fails instead of causing script to exit.