### PR TITLE
HC-522: Updated the start-verdi.sh to start verdi in either docker or podman

### DIFF
--- a/templates/start-verdi.sh
+++ b/templates/start-verdi.sh
@@ -5,5 +5,17 @@ export HOST_UID=$(id -u)
 export HOST_GID=$(id -g)
 mkdir -p ${DATA_DIR}/work
 chown -R ${HOST_UID}:${HOST_GID} $DATA_DIR
-cd ${HOME}/verdi/ops/hysds-dockerfiles/verdi
-/usr/local/bin/docker-compose up -d
+
+# First, need to read in the celeryconfig to get the podman commands
+export PYTHONPATH=${HYSDS_HOME}/verdi/etc:${PYTHONPATH}
+
+container_engine=$(python -c "from hysds.celery import app; import json; print(app.conf.get('CONTAINER_ENGINE'))")
+
+cd ${HYSDS_HOME}/verdi/ops/hysds-dockerfiles/verdi
+if [[ "${container_engine}" == "docker" ]]; then
+  /usr/local/bin/docker-compose up -d
+elif [[ "${container_engine}" == "podman" ]]; then
+  ./run_verdi_podman.sh
+else
+  echo "ERROR: ${container_engine} not supported. Cannot start verdi container."
+fi

--- a/templates/start-verdi.sh
+++ b/templates/start-verdi.sh
@@ -11,6 +11,9 @@ export PYTHONPATH=${HYSDS_HOME}/verdi/etc:${PYTHONPATH}
 
 container_engine=$(python -c "from hysds.celery import app; import json; print(app.conf.get('CONTAINER_ENGINE'))")
 
+# temporary print statement to make sure custom verdi AMI is using this script
+echo "Using HC-522 version of the start-verdi.sh"
+
 cd ${HYSDS_HOME}/verdi/ops/hysds-dockerfiles/verdi
 if [[ "${container_engine}" == "docker" ]]; then
   /usr/local/bin/docker-compose up -d

--- a/templates/start-verdi.sh
+++ b/templates/start-verdi.sh
@@ -11,9 +11,6 @@ export PYTHONPATH=${HYSDS_HOME}/verdi/etc:${PYTHONPATH}
 
 container_engine=$(python -c "from hysds.celery import app; import json; print(app.conf.get('CONTAINER_ENGINE'))")
 
-# temporary print statement to make sure custom verdi AMI is using this script
-echo "Using HC-522 version of the start-verdi.sh"
-
 cd ${HYSDS_HOME}/verdi/ops/hysds-dockerfiles/verdi
 if [[ "${container_engine}" == "docker" ]]; then
   /usr/local/bin/docker-compose up -d


### PR DESCRIPTION
- The `start-verdi.sh` script was updated such that it will now be able to start running Verdi in either docker or podman.
- It determines this by reading in the celeryconfig and looking at the `CONTAINER_ENGINE` variable.
- This PR coincides with the following PRs from the other repos:
  - https://github.com/hysds/hysds/pull/189
  - https://github.com/hysds/hysds-dockerfiles/pull/11

