### PR TITLE
HC-522-update: Use start-verdi from code bundle deployment if it exists

### DIFF
--- a/templates/start-verdi.sh
+++ b/templates/start-verdi.sh
@@ -1,21 +1,27 @@
 #!/bin/bash
+
 export HYSDS_HOME=$HOME
-export DATA_DIR=/data
-export HOST_UID=$(id -u)
-export HOST_GID=$(id -g)
-mkdir -p ${DATA_DIR}/work
-chown -R ${HOST_UID}:${HOST_GID} $DATA_DIR
 
-# First, need to read in the celeryconfig to get the podman commands
-export PYTHONPATH=${HYSDS_HOME}/verdi/etc:${PYTHONPATH}
-
-container_engine=$(python -c "from hysds.celery import app; import json; print(app.conf.get('CONTAINER_ENGINE'))")
-
-cd ${HYSDS_HOME}/verdi/ops/hysds-dockerfiles/verdi
-if [[ "${container_engine}" == "docker" ]]; then
-  /usr/local/bin/docker-compose up -d
-elif [[ "${container_engine}" == "podman" ]]; then
-  ./run_verdi_podman.sh
+if [ -f ${HYSDS_HOME}/verdi/bin/start-verdi.sh ]; then
+  ${HYSDS_HOME}/verdi/bin/start-verdi.sh;
 else
-  echo "ERROR: ${container_engine} not supported. Cannot start verdi container."
+  export DATA_DIR=/data
+  export HOST_UID=$(id -u)
+  export HOST_GID=$(id -g)
+  mkdir -p ${DATA_DIR}/work
+  chown -R ${HOST_UID}:${HOST_GID} $DATA_DIR
+
+  # First, need to read in the celeryconfig to get the podman commands
+  export PYTHONPATH=${HYSDS_HOME}/verdi/etc:${PYTHONPATH}
+
+  container_engine=$(python -c "from hysds.celery import app; import json; print(app.conf.get('CONTAINER_ENGINE'))")
+
+  cd ${HYSDS_HOME}/verdi/ops/hysds-dockerfiles/verdi
+  if [[ "${container_engine}" == "docker" ]]; then
+    /usr/local/bin/docker-compose up -d
+  elif [[ "${container_engine}" == "podman" ]]; then
+    ./run_verdi_podman.sh
+  else
+    echo "ERROR: ${container_engine} not supported. Cannot start verdi container."
+  fi
 fi


### PR DESCRIPTION
This PR updates the existing start-verdi.sh script such that if it detects a custom script under `$HYSDS_HOME/verdi/bin`, it will use that instead. This allows adaptation to be able to test custom changes to the deploy their own versions of the verdi script.
